### PR TITLE
Unify JD input

### DIFF
--- a/frontend/src/Components/Helpers/JdForm/UnifiedJdInput.jsx
+++ b/frontend/src/Components/Helpers/JdForm/UnifiedJdInput.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { explainJdText, explainJdUrl } from "../../../services/jobDescriptionService";
+import { usePdf } from "../../PdfContext";
+
+export default function UnifiedJdInput({ user, onExplanationReceived, onFocus, onError }) {
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const { masterDocID } = usePdf();
+
+  const isUrl = (str) => {
+    try {
+      new URL(str);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) {
+      alert("Please enter a job description or URL");
+      return;
+    }
+    if (!masterDocID) {
+      alert("Please set a master resume before submitting a job description.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const idToken = await user.getIdToken();
+      let data;
+      if (isUrl(input.trim())) {
+        data = await explainJdUrl(input.trim(), idToken);
+      } else {
+        data = await explainJdText(input.trim(), idToken);
+      }
+      const { explanation, job_description } = data;
+      onExplanationReceived(explanation, job_description);
+      setInput("");
+    } catch (err) {
+      console.log("Error processing JD", err);
+      if (isUrl(input.trim())) {
+        if (onError) {
+          onError("Failed to fetch job description from URL. Please try copying and pasting the text instead.");
+        } else {
+          alert("Error fetching or processing the job description. Please try to copy/paste the job description instead.");
+        }
+      } else {
+        if (onError) {
+          onError("Error processing job description. Please try again.");
+        } else {
+          alert("Error processing job description. Please try again.");
+        }
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Enter a job description URL or paste the description in as text</h3>
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onFocus={onFocus}
+        placeholder="Paste a job description or URL…"
+        rows={6}
+        cols={50}
+      />
+      <br />
+      <button type="submit" disabled={isLoading}>
+        {isLoading ? "Processing…" : "Submit"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/Components/Pages/AddJd/AddJd.jsx
+++ b/frontend/src/Components/Pages/AddJd/AddJd.jsx
@@ -1,12 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { onAuthStateChanged } from "firebase/auth";
 import { useNavigate } from "react-router-dom";
-import { Link } from "react-router-dom";
 
 import { auth } from "../../../firebase";
 import Sidebar from "../../Sidebar/Sidebar";
-import JdFromUrl from "../../Helpers/JdForm/JdFromUrl";
-import JdFromText from "../../Helpers/JdForm/JdFromText";
+import UnifiedJdInput from "../../Helpers/JdForm/UnifiedJdInput";
 import { usePdf } from "../../PdfContext";
 import { getSimilarityScore } from "../../../services/resumeService";
 import { useTargetedResume } from "../../TargetedResumeContext";
@@ -90,19 +88,18 @@ export default function AddJd() {
 
 
 
-            <ToolSection title="Paste a Job Description (URL)" delay={100}>
-            <JdFromUrl user={user} onExplanationReceived={handleExplanationReceived} onError={handleUrlError} />
+            <ToolSection title="Paste a Job Description" delay={100} extraClass={highlightTextInput ? "highlighted-section" : ""}>
+            <UnifiedJdInput
+              user={user}
+              onExplanationReceived={handleExplanationReceived}
+              onError={handleUrlError}
+              onFocus={clearErrorState}
+            />
             {urlError && <div className="url-error-message">{urlError}</div>}
             </ToolSection>
 
-            <div className="divider"><strong>&mdash; OR &mdash;</strong></div>
-
-            <ToolSection title="Paste a Job Description (Text)" delay={200} extraClass={highlightTextInput ? "highlighted-section" : ""}>
-            <JdFromText user={user} onExplanationReceived={handleExplanationReceived} onFocus={clearErrorState} />
-            </ToolSection>
-
             {jdExplanation && (
-            <ToolSection title="Gemini's Explanation" delay={300}>
+            <ToolSection title="Job Description Summary" delay={300}>
                 <p>{jdExplanation}</p>
             </ToolSection>
             )}


### PR DESCRIPTION
## Summary
- create a `UnifiedJdInput` component to accept either a URL or text
- update AddJd page to use the new unified input component
- rename the explanation section to "Job Description Summary"

## Testing
- `npm test --prefix frontend --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68661df764e483218387844d9e6697f8