### PR TITLE
Add comprehensive React tests

### DIFF
--- a/frontend/__tests__/AddJd.test.jsx
+++ b/frontend/__tests__/AddJd.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AddJd from '../src/Components/Pages/AddJd/AddJd';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div />);
+jest.mock('../src/Components/Helpers/JdForm/UnifiedJdInput', () => () => <div />);
+jest.mock('../src/Components/PdfContext', () => ({ usePdf: () => ({ masterDocID: '1' }) }));
+jest.mock('../src/Components/TargetedResumeContext', () => ({
+  useTargetedResume: () => ({ setJdExplanation: jest.fn(), setJdContent: jest.fn(), jdContent: '' })
+}));
+
+test('renders Add Job Description header', () => {
+  render(<AddJd />);
+  expect(screen.getByText(/Add Job Description/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/App.test.jsx
+++ b/frontend/__tests__/App.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import App from '../src/App';
+
+// Mock child pages so routing works without their implementations
+jest.mock('../src/Components/Pages/Signup/Signup', () => () => <div>SignUp Page</div>);
+jest.mock('../src/Components/Pages/WelcomeInstructions/WelcomeInstructions', () => () => <div>Welcome Page</div>);
+jest.mock('../src/Components/Helpers/Header/Header', () => () => <div data-testid="header">HEADER</div>);
+
+test('hides header on signup page', () => {
+  render(
+    <MemoryRouter initialEntries={['/signup']}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.queryByTestId('header')).not.toBeInTheDocument();
+});
+
+test('shows header on welcome page', () => {
+  render(
+    <MemoryRouter initialEntries={['/welcome']}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByTestId('header')).toBeInTheDocument();
+});

--- a/frontend/__tests__/ForgotPassword.test.jsx
+++ b/frontend/__tests__/ForgotPassword.test.jsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ForgotPassword from '../src/Components/Helpers/ForgotPassword/ForgotPassword';
+
+test('placeholder component renders without crashing', () => {
+  render(<ForgotPassword />);
+});

--- a/frontend/__tests__/GenerateAndEditResume.test.jsx
+++ b/frontend/__tests__/GenerateAndEditResume.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GenerateAndEditResume from '../src/Components/Pages/GenerateAndEditResume/GenerateAndEditResume';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div />);
+jest.mock('../src/Components/PdfContext', () => ({
+  usePdf: () => ({ masterDocID: '1', fetchPdfsAndMaster: jest.fn() })
+}));
+jest.mock('../src/Components/TargetedResumeContext', () => ({
+  useTargetedResume: () => ({ jdContent: '', generatedHtml: '', setGeneratedHtml: jest.fn() })
+}));
+
+test('renders Generate & Edit Resume header', () => {
+  render(<GenerateAndEditResume />);
+  expect(screen.getByText(/Generate & Edit Resume/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/Header.test.jsx
+++ b/frontend/__tests__/Header.test.jsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Header from '../src/Components/Helpers/Header/Header';
+
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (_, cb) => {
+    cb(null);
+    return jest.fn();
+  }
+}));
+jest.mock('../src/services/profileService', () => ({ getProfile: jest.fn() }));
+
+test('renders nothing when user not logged in', () => {
+  const { container } = render(<Header />);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/frontend/__tests__/InfoBox.test.jsx
+++ b/frontend/__tests__/InfoBox.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InfoBox from '../src/Components/UI/InfoBox/InfoBox';
+
+test('renders title and items', () => {
+  render(<InfoBox title="Tips" items={["One", "Two"]} />);
+  expect(screen.getByText(/Tips/)).toBeInTheDocument();
+  expect(screen.getByText('One')).toBeInTheDocument();
+});

--- a/frontend/__tests__/JdFromText.test.jsx
+++ b/frontend/__tests__/JdFromText.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import JdFromText from '../src/Components/Helpers/JdForm/JdFromText';
+
+jest.mock('../../../src/Components/PdfContext', () => ({ usePdf: () => ({ masterDocID: '1' }) }));
+jest.mock('../../../src/services/jobDescriptionService', () => ({ explainJdText: jest.fn().mockResolvedValue({ explanation: '', job_description: '' }) }));
+
+test('renders JD text area', () => {
+  render(<JdFromText user={{ getIdToken: jest.fn() }} onExplanationReceived={jest.fn()} />);
+  expect(screen.getByPlaceholderText(/Enter job description/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/JdFromUrl.test.jsx
+++ b/frontend/__tests__/JdFromUrl.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import JdFromUrl from '../src/Components/Helpers/JdForm/JdFromUrl';
+
+jest.mock('../../../src/Components/PdfContext', () => ({ usePdf: () => ({ masterDocID: '1' }) }));
+jest.mock('../../../src/services/jobDescriptionService', () => ({ explainJdUrl: jest.fn().mockResolvedValue({ explanation: '', job_description: '' }) }));
+
+test('renders URL input', () => {
+  render(<JdFromUrl user={{ getIdToken: jest.fn() }} onExplanationReceived={jest.fn()} />);
+  expect(screen.getByPlaceholderText(/https:\/\/…/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/LandingPage.test.jsx
+++ b/frontend/__tests__/LandingPage.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LandingPage from '../src/Components/Pages/LandingPage/LandingPage';
+
+test('renders How RezuMe Works section', () => {
+  render(<LandingPage />);
+  expect(screen.getByText(/How RezuMe Works/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/LoginOnly.test.jsx
+++ b/frontend/__tests__/LoginOnly.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import LoginOnly from '../src/Components/Pages/LoginOnly/LoginOnly';
+
+jest.mock('../src/services/authHandlers', () => ({
+  handleLogin: jest.fn().mockResolvedValue({ email: 'test@test.com' }),
+  handlePasswordReset: jest.fn().mockResolvedValue()
+}));
+
+test('allows entering email and password', async () => {
+  render(<LoginOnly />);
+  await userEvent.type(screen.getByPlaceholderText(/Email/i), 'user@test.com');
+  await userEvent.type(screen.getByPlaceholderText(/Password/i), 'pass');
+  expect(screen.getByPlaceholderText(/Email/i)).toHaveValue('user@test.com');
+});

--- a/frontend/__tests__/NavigationButton.test.jsx
+++ b/frontend/__tests__/NavigationButton.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NavigationButton from '../src/Components/UI/NavigationButton/NavigationButton';
+import { MemoryRouter } from 'react-router-dom';
+
+test('renders link with correct href', () => {
+  render(
+    <MemoryRouter>
+      <NavigationButton to="/test">Go</NavigationButton>
+    </MemoryRouter>
+  );
+  expect(screen.getByRole('link', { name: /Go/i })).toHaveAttribute('href', '/test');
+});

--- a/frontend/__tests__/PdfContext.test.jsx
+++ b/frontend/__tests__/PdfContext.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PdfProvider } from '../src/Components/PdfContext';
+
+test('PdfProvider renders children', () => {
+  render(
+    <PdfProvider>
+      <div data-testid="child" />
+    </PdfProvider>
+  );
+  expect(screen.getByTestId('child')).toBeInTheDocument();
+});

--- a/frontend/__tests__/ProfileExtractor.test.jsx
+++ b/frontend/__tests__/ProfileExtractor.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ProfileExtractor from '../src/Components/Helpers/ProfileExtractor/ProfileExtractor';
+
+jest.mock('../../../src/services/resumeService', () => ({
+  extractResumeProfileLLM: jest.fn().mockResolvedValue({ skills: [], education: [], experience: [] })
+}));
+jest.mock('../../../src/services/jobDescriptionService', () => ({
+  extractJdProfile: jest.fn().mockResolvedValue({ required_skills: [], required_education: [], required_experience: [], responsibilities: [] })
+}));
+jest.mock('../../../src/services/keywordService', () => ({
+  getSelectedKeywords: jest.fn().mockResolvedValue([]),
+  addSelectedKeywords: jest.fn(),
+  removeSelectedKeyword: jest.fn(),
+  fetchHighlights: jest.fn().mockResolvedValue({ matched_resume: [], matched_jd: [] })
+}));
+
+test('renders loading text initially', () => {
+  render(<ProfileExtractor masterDocID="1" jdText="test" />);
+  expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/ResumeArchive.test.jsx
+++ b/frontend/__tests__/ResumeArchive.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ResumeArchive from '../src/Components/Pages/ResumeArchive/ResumeArchive';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div>Sidebar</div>);
+jest.mock('../src/Components/Helpers/ResumeLibrary/ResumeViewerModal', () => () => <div />);
+jest.mock('../src/Components/PdfContext', () => ({
+  usePdf: () => ({ pdfs: [], handleDelete: jest.fn() })
+}));
+
+test('renders archive header', () => {
+  render(<ResumeArchive />);
+  expect(screen.getByText(/RezuMe Archive/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/ResumeBuilderForm.test.jsx
+++ b/frontend/__tests__/ResumeBuilderForm.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ResumeBuilderForm from '../src/Components/Pages/ResumeBuilderForm/ResumeBuilderForm';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div />);
+
+test('shows Personal Info step', () => {
+  render(<ResumeBuilderForm />);
+  expect(screen.getByText(/Personal Information/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/ResumeDiffViewer.test.jsx
+++ b/frontend/__tests__/ResumeDiffViewer.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ResumeDiffViewer } from '../src/Components/Helpers/StructuredDiffEditor/ResumeDiffViewer';
+
+test('renders diff list items', () => {
+  const ast = [{ type: 'paragraph', diff: [{ text: 'hello' }] }];
+  render(<ResumeDiffViewer astWithDiff={ast} />);
+  expect(screen.getByText('hello')).toBeInTheDocument();
+});

--- a/frontend/__tests__/ResumeLibrary.test.jsx
+++ b/frontend/__tests__/ResumeLibrary.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ResumeLibrary from '../src/Components/Helpers/ResumeLibrary/ResumeLibrary';
+
+jest.mock('../src/Components/PdfContext', () => ({
+  usePdf: () => ({
+    pdfs: [],
+    masterDocID: null,
+    loading: false,
+    statusMessage: '',
+    handleDelete: jest.fn(),
+    handleSetMaster: jest.fn()
+  })
+}));
+jest.mock('../src/Components/Helpers/ResumeLibrary/ResumeViewerModal', () => () => <div />);
+
+test('shows message when no resumes', () => {
+  render(<ResumeLibrary />);
+  expect(screen.getByText(/No resumes uploaded yet/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/ResumeViewerModal.test.jsx
+++ b/frontend/__tests__/ResumeViewerModal.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ResumeViewerModal from '../src/Components/Helpers/ResumeLibrary/ResumeViewerModal';
+
+test('renders modal when open', () => {
+  render(<ResumeViewerModal isOpen onClose={jest.fn()} pdfUrl="test.pdf" />);
+  expect(screen.getByText(/Resume Preview/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/ScrollToTop.test.jsx
+++ b/frontend/__tests__/ScrollToTop.test.jsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScrollToTop from '../src/Components/Helpers/ScrollToTop/ScrollToTop';
+import { MemoryRouter } from 'react-router-dom';
+
+test('renders nothing', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <ScrollToTop />
+    </MemoryRouter>
+  );
+  expect(container).toBeEmptyDOMElement();
+});

--- a/frontend/__tests__/SelectKeywords.test.jsx
+++ b/frontend/__tests__/SelectKeywords.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SelectKeywords from '../src/Components/Helpers/SelectKeywords/SelectKeywords';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div />);
+jest.mock('../src/Components/PdfContext', () => ({ usePdf: () => ({ masterDocID: '1' }) }));
+jest.mock('../src/Components/TargetedResumeContext', () => ({ useTargetedResume: () => ({ jdContent: 'x' }) }));
+
+test('renders Select Keywords title', () => {
+  render(<SelectKeywords />);
+  expect(screen.getByText(/Select Keywords/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/Sidebar.test.jsx
+++ b/frontend/__tests__/Sidebar.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import Sidebar from '../src/Components/Sidebar/Sidebar';
+import { MemoryRouter } from 'react-router-dom';
+
+test('toggle button collapses sidebar', async () => {
+  render(
+    <MemoryRouter>
+      <Sidebar user={{}} />
+    </MemoryRouter>
+  );
+  const button = screen.getByTitle(/Collapse sidebar/i);
+  await userEvent.click(button);
+  expect(button).toBeInTheDocument();
+});

--- a/frontend/__tests__/Signup.test.jsx
+++ b/frontend/__tests__/Signup.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import LoginSignup from '../src/Components/Pages/Signup/Signup';
+
+jest.mock('../src/services/authHandlers', () => ({
+  handleSignup: jest.fn().mockResolvedValue({ email: 'a@test.com' })
+}));
+
+test('password visibility toggle works', async () => {
+  render(<LoginSignup />);
+  const password = screen.getByPlaceholderText(/Password/i);
+  const toggle = screen.getByRole('button', { hidden: true });
+  expect(password).toHaveAttribute('type', 'password');
+  await userEvent.click(toggle);
+  expect(password).toHaveAttribute('type', 'text');
+});

--- a/frontend/__tests__/StructuredResumeEditor.test.jsx
+++ b/frontend/__tests__/StructuredResumeEditor.test.jsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StructuredResumeEditor from '../src/Components/Helpers/StructuredDiffEditor/StructuredResumeEditor';
+
+test('placeholder component renders', () => {
+  render(<StructuredResumeEditor />);
+});

--- a/frontend/__tests__/TargetedResumeContext.test.jsx
+++ b/frontend/__tests__/TargetedResumeContext.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TargetedResumeProvider, useTargetedResume } from '../src/Components/TargetedResumeContext';
+
+function Consumer() {
+  const { setJdContent } = useTargetedResume();
+  setJdContent('test');
+  return <div>child</div>;
+}
+
+test('TargetedResumeProvider provides context', () => {
+  render(
+    <TargetedResumeProvider>
+      <Consumer />
+    </TargetedResumeProvider>
+  );
+  expect(screen.getByText('child')).toBeInTheDocument();
+});

--- a/frontend/__tests__/TinyDiffEditor.test.jsx
+++ b/frontend/__tests__/TinyDiffEditor.test.jsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TinyDiffEditor from '../src/Components/Helpers/TinyDiffEditor/TinyDiffEditor';
+
+test('renders TinyDiffEditor', () => {
+  render(<TinyDiffEditor value="<p>Hello</p>" onEditorChange={() => {}} />);
+});

--- a/frontend/__tests__/UnifiedJdInput.test.jsx
+++ b/frontend/__tests__/UnifiedJdInput.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UnifiedJdInput from '../src/Components/Helpers/JdForm/UnifiedJdInput';
+
+jest.mock('../../../src/Components/PdfContext', () => ({ usePdf: () => ({ masterDocID: '1' }) }));
+jest.mock('../../../src/services/jobDescriptionService', () => ({
+  explainJdUrl: jest.fn().mockResolvedValue({ explanation: '', job_description: '' }),
+  explainJdText: jest.fn().mockResolvedValue({ explanation: '', job_description: '' })
+}));
+
+test('renders textarea for job description', () => {
+  render(<UnifiedJdInput user={{ getIdToken: jest.fn() }} onExplanationReceived={jest.fn()} />);
+  expect(screen.getByPlaceholderText(/Paste a job description/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/UploadFileBox.test.jsx
+++ b/frontend/__tests__/UploadFileBox.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import UploadFileBox from '../src/Components/UI/UploadFileBox/UploadFileBox';
+
+test('triggers onUpload when Upload clicked', async () => {
+  const onUpload = jest.fn();
+  render(<UploadFileBox onUpload={onUpload} accept="application/pdf" />);
+  const input = screen.getByRole('textbox', { hidden: true });
+  const file = new File(['x'], 'test.pdf', { type: 'application/pdf' });
+  await userEvent.upload(input, file);
+  await userEvent.click(screen.getByText(/Upload/i));
+  expect(onUpload).toHaveBeenCalled();
+});

--- a/frontend/__tests__/UploadPdf.test.jsx
+++ b/frontend/__tests__/UploadPdf.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import UploadPdf from '../src/Components/Helpers/UploadPdf/UploadPdf';
+
+jest.mock('../src/Components/PdfContext', () => ({
+  usePdf: () => ({ uploadPdf: jest.fn() })
+}));
+
+test('calls onUpload when file selected', async () => {
+  render(<UploadPdf />);
+  const input = screen.getByText(/Upload PDF/i).closest('input');
+  const file = new File(['dummy'], 'test.pdf', { type: 'application/pdf' });
+  await userEvent.upload(input, file);
+});

--- a/frontend/__tests__/UploadResume.test.jsx
+++ b/frontend/__tests__/UploadResume.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UploadResume from '../src/Components/Pages/UploadResume/UploadResume';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div />);
+jest.mock('../src/Components/Helpers/UploadPdf/UploadPdf', () => () => <div />);
+jest.mock('../src/Components/Helpers/ResumeLibrary/ResumeLibrary', () => () => <div />);
+jest.mock('../src/Components/PdfContext', () => ({ usePdf: () => ({ fetchPdfsAndMaster: jest.fn(), masterDocID: null }) }));
+
+test('renders Upload Resume title', () => {
+  render(<UploadResume />);
+  expect(screen.getByText(/Upload Resume/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/UserProfile.test.jsx
+++ b/frontend/__tests__/UserProfile.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserProfile from '../src/Components/Pages/UserProfile/UserProfile';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div />);
+jest.mock('../src/services/profileService', () => ({
+  getProfile: jest.fn().mockResolvedValue({})
+}));
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (_, cb) => {
+    cb(null);
+    return jest.fn();
+  }
+}));
+
+test('shows loading when no user', () => {
+  render(<UserProfile />);
+  expect(screen.getByText(/Loading user profile/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/WarningBox.test.jsx
+++ b/frontend/__tests__/WarningBox.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WarningBox from '../src/Components/UI/WarningBox/WarningBox';
+
+test('renders warning message', () => {
+  render(<WarningBox>Be careful!</WarningBox>);
+  expect(screen.getByText(/Be careful!/i)).toBeInTheDocument();
+});

--- a/frontend/__tests__/WelcomeInstructions.test.jsx
+++ b/frontend/__tests__/WelcomeInstructions.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WelcomeInstructions from '../src/Components/Pages/WelcomeInstructions/WelcomeInstructions';
+
+jest.mock('../src/Components/Sidebar/Sidebar', () => () => <div />);
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (_, cb) => {
+    cb({ displayName: 'User' });
+    return jest.fn();
+  }
+}));
+
+test('shows getting started heading', () => {
+  render(<WelcomeInstructions />);
+  expect(screen.getByText(/Getting Started with RezuMe/i)).toBeInTheDocument();
+});

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});


### PR DESCRIPTION
## Summary
- centralize React component tests under `frontend/__tests__`
- remove default CRA test

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0e9fc1f883219ce36582f467aea6