### PR TITLE
Add job description archive feature

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -37,6 +37,14 @@ from llm_utils import (
     highlight_profile_similarity,
     generate_targeted_resume_html
 )
+from jd_storage import (
+    add_job_description,
+    list_job_descriptions,
+    set_active_jd,
+    get_active_jd,
+    delete_job_description,
+    get_job_description
+)
 
 from user_profile_utils import (
     upload_profile_picture,
@@ -60,6 +68,56 @@ def receive_jd():
 @verify_firebase_token
 def receive_jd_url():
     return handle_jd_from_url(request.get_json().get("url", ""))
+
+# Save a job description with a title
+@app.route("/api/save_jd_text", methods=["POST"])
+@verify_firebase_token
+def api_save_jd_text():
+    data = request.get_json() or {}
+    title = data.get("title")
+    jd_text = data.get("jd")
+    if not title or not jd_text:
+        return jsonify({"error": "Missing title or jd"}), 400
+    jd = add_job_description(title, jd_text)
+    return jsonify(jd), 200
+
+# List saved job descriptions
+@app.route("/api/list_jds", methods=["GET"])
+@verify_firebase_token
+def api_list_jds():
+    jds = list_job_descriptions()
+    return jsonify({"jds": jds}), 200
+
+# Set active job description
+@app.route("/api/set_active_jd", methods=["POST"])
+@verify_firebase_token
+def api_set_active_jd():
+    data = request.get_json() or {}
+    jd_id = data.get("id")
+    if not jd_id:
+        return jsonify({"error": "Missing id"}), 400
+    jd = set_active_jd(jd_id)
+    if not jd:
+        return jsonify({"error": "JD not found"}), 404
+    return jsonify({"activeJdID": jd_id, "jd": jd}), 200
+
+# Get active job description id
+@app.route("/api/get_active_jd", methods=["GET"])
+@verify_firebase_token
+def api_get_active_jd():
+    active = get_active_jd()
+    return jsonify({"activeJdID": active}), 200
+
+# Delete a job description
+@app.route("/api/delete_jd", methods=["POST"])
+@verify_firebase_token
+def api_delete_jd():
+    data = request.get_json() or {}
+    jd_id = data.get("id")
+    if not jd_id:
+        return jsonify({"error": "Missing id"}), 400
+    delete_job_description(jd_id)
+    return jsonify({"deleted": True}), 200
 
 #============================= PDF Management ===========================================
     

--- a/backend/data/job_descriptions.json
+++ b/backend/data/job_descriptions.json
@@ -1,0 +1,1 @@
+{"jds": [], "active": null}

--- a/backend/jd_storage.py
+++ b/backend/jd_storage.py
@@ -1,0 +1,71 @@
+import os
+import json
+import uuid
+from threading import Lock
+
+FILE_PATH = os.path.join(os.path.dirname(__file__), 'data', 'job_descriptions.json')
+_lock = Lock()
+
+
+def _load():
+    if not os.path.exists(FILE_PATH):
+        with open(FILE_PATH, 'w') as f:
+            json.dump({'jds': [], 'active': None}, f)
+    with open(FILE_PATH, 'r') as f:
+        return json.load(f)
+
+
+def _save(data):
+    with open(FILE_PATH, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def add_job_description(title: str, text: str) -> dict:
+    with _lock:
+        data = _load()
+        jd = {'id': str(uuid.uuid4()), 'title': title, 'text': text}
+        data['jds'].append(jd)
+        _save(data)
+        return jd
+
+
+def list_job_descriptions() -> list:
+    with _lock:
+        data = _load()
+        return data.get('jds', [])
+
+
+def set_active_jd(jd_id: str) -> dict | None:
+    """Set the active job description ID and return the JD object."""
+    with _lock:
+        data = _load()
+        jd = next((j for j in data.get('jds', []) if j['id'] == jd_id), None)
+        data['active'] = jd_id if jd else None
+        _save(data)
+        return jd
+
+
+def get_active_jd() -> str | None:
+    with _lock:
+        data = _load()
+        return data.get('active')
+
+
+def get_job_description(jd_id: str) -> dict | None:
+    """Return the job description with the given ID if it exists."""
+    with _lock:
+        data = _load()
+        for jd in data.get('jds', []):
+            if jd['id'] == jd_id:
+                return jd
+    return None
+
+
+def delete_job_description(jd_id: str):
+    """Delete a job description by ID and clear active if needed."""
+    with _lock:
+        data = _load()
+        data['jds'] = [jd for jd in data.get('jds', []) if jd['id'] != jd_id]
+        if data.get('active') == jd_id:
+            data['active'] = None
+        _save(data)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import ResumeArchive from './Components/Pages/ResumeArchive/ResumeArchive';
 import Header from './Components/Helpers/Header/Header';
 import { PdfProvider } from './Components/PdfContext';
 import { TargetedResumeProvider } from './Components/TargetedResumeContext';
+import { JdProvider } from './Components/JobDescription/JdContext';
 import SelectKeywords from './Components/Helpers/SelectKeywords/SelectKeywords';
 
 
@@ -36,6 +37,7 @@ function App() {
   <>
     {!hideHeaderOn.includes(pathname) && <Header />}
     <PdfProvider>
+    <JdProvider>
     <TargetedResumeProvider>
         <Routes>
             {/* App root: Landing page */}
@@ -76,6 +78,7 @@ function App() {
             <Route path="*" element={<Navigate to="/signup" replace />} />
         </Routes>
     </TargetedResumeProvider>
+    </JdProvider>
     </PdfProvider>
     </>
   );

--- a/frontend/src/Components/JobDescription/JdContext.js
+++ b/frontend/src/Components/JobDescription/JdContext.js
@@ -1,0 +1,91 @@
+import React, { createContext, useContext, useState, useCallback, useEffect } from "react";
+import { auth } from "../../firebase";
+import { onIdTokenChanged } from "firebase/auth";
+import { saveJobDescription, listJobDescriptions, setActiveJobDescription, getActiveJobDescription, deleteJobDescription } from "../../services/jobDescriptionService";
+
+const JdContext = createContext();
+
+export function useJd() {
+    return useContext(JdContext);
+}
+
+export function JdProvider({ children }) {
+    const [jds, setJds] = useState([]);
+    const [activeJdID, setActiveJdID] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    const fetchJdsAndActive = useCallback(async () => {
+        setLoading(true);
+        try {
+            const idToken = await auth.currentUser.getIdToken();
+            const list = await listJobDescriptions(idToken);
+            setJds(list.jds || list);
+            const active = await getActiveJobDescription(idToken);
+            setActiveJdID(active.activeJdID);
+        } catch (e) {
+            console.error("Error loading job descriptions", e);
+        }
+        setLoading(false);
+    }, []);
+
+    useEffect(() => {
+        const unsubscribe = onIdTokenChanged(auth, (user) => {
+            if (user) {
+                fetchJdsAndActive();
+            } else {
+                setJds([]);
+                setActiveJdID(null);
+            }
+        });
+        return () => unsubscribe();
+    }, [fetchJdsAndActive]);
+
+    const addJd = async (title, text) => {
+        try {
+            const idToken = await auth.currentUser.getIdToken();
+            await saveJobDescription(title, text, idToken);
+            fetchJdsAndActive();
+        } catch (e) {
+            console.error("Failed to save job description", e);
+        }
+    };
+
+    const setActive = async (id) => {
+        try {
+            const idToken = await auth.currentUser.getIdToken();
+            const res = await setActiveJobDescription(id, idToken);
+            setActiveJdID(id);
+            return res.jd;
+        } catch (e) {
+            console.error("Failed to set active JD", e);
+            return null;
+        }
+    };
+
+    const removeJd = async (id) => {
+        try {
+            const idToken = await auth.currentUser.getIdToken();
+            await deleteJobDescription(id, idToken);
+            fetchJdsAndActive();
+        } catch (e) {
+            console.error("Failed to delete JD", e);
+        }
+    };
+
+    const value = {
+        jds,
+        activeJdID,
+        loading,
+        addJd,
+        setActive,
+        fetchJdsAndActive,
+        removeJd,
+    };
+
+    return (
+        <JdContext.Provider value={value}>
+            {children}
+        </JdContext.Provider>
+    );
+}
+

--- a/frontend/src/Components/JobDescription/JobDescriptionLibrary.jsx
+++ b/frontend/src/Components/JobDescription/JobDescriptionLibrary.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { useJd } from "./JdContext";
+
+export default function JobDescriptionLibrary() {
+    const { jds, activeJdID, setActive, removeJd, loading } = useJd();
+    const [expanded, setExpanded] = useState(null);
+
+    if (loading) return <p>Loading...</p>;
+    if (jds.length === 0) return <p>No job descriptions saved.</p>;
+
+    return (
+        <div className="tool-section" data-aos="fade-up">
+            <h2>Saved Job Descriptions</h2>
+            <ul style={{ listStyle: "none", padding: 0 }}>
+                {jds.map(jd => (
+                    <li
+                        key={jd.id}
+                        style={{
+                            border: "1px solid #ccc",
+                            borderRadius: 8,
+                            padding: 10,
+                            marginBottom: 10,
+                            background: jd.id === activeJdID ? "#e6ffe6" : "#f9f9f9",
+                        }}
+                    >
+                        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                            <span>
+                                <strong>{jd.title}</strong>
+                                {jd.id === activeJdID && (
+                                    <span style={{ color: "green", fontWeight: "bold", marginLeft: 10 }}>
+                                        (Active)
+                                    </span>
+                                )}
+                            </span>
+                            <span>
+                                <button onClick={() => setExpanded(expanded === jd.id ? null : jd.id)} style={{ marginRight: 8 }}>
+                                    {expanded === jd.id ? "Hide" : "View"}
+                                </button>
+                                {jd.id !== activeJdID && (
+                                    <button onClick={() => setActive(jd.id)} style={{ marginRight: 8 }}>
+                                        Set Active
+                                    </button>
+                                )}
+                                <button onClick={() => removeJd(jd.id)}>Delete</button>
+                            </span>
+                        </div>
+                        {expanded === jd.id && (
+                            <pre style={{ whiteSpace: "pre-wrap", marginTop: 8 }}>{jd.text}</pre>
+                        )}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+

--- a/frontend/src/Components/Pages/AddJd/AddJd.jsx
+++ b/frontend/src/Components/Pages/AddJd/AddJd.jsx
@@ -6,6 +6,8 @@ import { auth } from "../../../firebase";
 import Sidebar from "../../Sidebar/Sidebar";
 import UnifiedJdInput from "../../Helpers/JdForm/UnifiedJdInput";
 import { usePdf } from "../../PdfContext";
+import { useJd } from "../../JobDescription/JdContext";
+import JobDescriptionLibrary from "../../JobDescription/JobDescriptionLibrary";
 import { getSimilarityScore } from "../../../services/resumeService";
 import { useTargetedResume } from "../../TargetedResumeContext";
 import InfoBox from "../../UI/InfoBox/InfoBox";
@@ -19,6 +21,7 @@ export default function AddJd() {
     const navigate = useNavigate();
     const [user, setUser] = useState(null);
     const { masterDocID } = usePdf();
+    const { addJd, jds, activeJdID } = useJd();
     const { jdExplanation, setJdExplanation, jdContent, setJdContent, initialSim, setInitialSim } = useTargetedResume();
     const [urlError, setUrlError] = useState("");
     const [highlightTextInput, setHighlightTextInput] = useState(false);
@@ -32,6 +35,17 @@ export default function AddJd() {
         if (!masterDocID || !jdContent) return;
         getSimilarityScore(masterDocID, jdContent).then(({ master_score }) => setInitialSim(master_score)).catch(console.error);
     }, [masterDocID, jdContent]);
+
+    useEffect(() => {
+        if (!masterDocID || !activeJdID) return;
+        const jd = jds.find(j => j.id === activeJdID);
+        if (!jd) return;
+        setJdContent(jd.text);
+        setJdExplanation("");
+        getSimilarityScore(masterDocID, jd.text)
+            .then(({ master_score }) => setInitialSim(master_score))
+            .catch(console.error);
+    }, [activeJdID, jds, masterDocID]);
 
     const handleExplanationReceived = (exp, raw) => {
         setJdExplanation(exp);
@@ -113,7 +127,21 @@ export default function AddJd() {
                             }}>{initialSim}%</span>
                         </p>
                     )}
+                    {jdContent && (
+                        <button
+                            type="button"
+                            className="navigation-button"
+                            onClick={() => {
+                                const title = prompt('Job Title');
+                                if (title) addJd(title, jdContent);
+                            }}
+                        >
+                            Save Job Description
+                        </button>
+                    )}
                 </ToolSection>
+
+                <JobDescriptionLibrary />
 
                 <div className="nav-buttons-row">
                     <button type="button" className="navigation-button" onClick={() => navigate(-1)} >  &larr; Back </button>

--- a/frontend/src/services/jobDescriptionService.js
+++ b/frontend/src/services/jobDescriptionService.js
@@ -103,3 +103,59 @@ export async function extractJdProfile(jdText, idToken) {
   if (!res.ok) throw new Error(await res.text());
   return await res.json(); // LLM text : { required_skills: [...], required_education: [...], ... }
 }
+
+export async function saveJobDescription(title, jdText, idToken) {
+  const res = await fetch("http://localhost:5001/api/save_jd_text", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${idToken}`
+    },
+    body: JSON.stringify({ title, jd: jdText })
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json();
+}
+
+export async function listJobDescriptions(idToken) {
+  const res = await fetch("http://localhost:5001/api/list_jds", {
+    headers: { "Authorization": `Bearer ${idToken}` }
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json();
+}
+
+export async function setActiveJobDescription(id, idToken) {
+  const res = await fetch("http://localhost:5001/api/set_active_jd", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${idToken}`
+    },
+    body: JSON.stringify({ id })
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json(); // { activeJdID, jd }
+}
+
+export async function getActiveJobDescription(idToken) {
+  const res = await fetch("http://localhost:5001/api/get_active_jd", {
+    headers: { "Authorization": `Bearer ${idToken}` }
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json();
+}
+
+export async function deleteJobDescription(id, idToken) {
+  const res = await fetch("http://localhost:5001/api/delete_jd", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${idToken}`
+    },
+    body: JSON.stringify({ id })
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return await res.json(); // { deleted: true }
+}
+


### PR DESCRIPTION
## Summary
- let users store job descriptions
- create JobDescription context and library UI
- provide API routes for saving/listing/selecting job descriptions
- wire up provider and save button in AddJd page
- enable deletion and viewing of saved JDs
- reprocess similarity whenever active JD changes

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: Missing Firebase base 64 key)*

------
https://chatgpt.com/codex/tasks/task_e_686b6c5b8620832388a28b7ecbc2487b